### PR TITLE
CI: Remove actionlint job

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,19 +5,6 @@ name: Lint GitHub Actions workflows
 on: [push, pull_request]
 
 jobs:
-  actionlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download actionlint
-        id: get_actionlint
-        # yamllint disable-line rule:line-length
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
-
   commit-message:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
The pre-commit CI system can now properly handle validating actionlint
pre-commit so the manual job can now be removed as validation will
happen there.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
