### PR TITLE
CI: Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,19 @@
+---
+name: Generate Relase Notes
+
+# yamllint disable-line rule:truthy
+on: push
+
+jobs:
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get tag
+        id: tag
+        uses: devops-actions/action-get-tag@v1.0.2
+      - name: Create Release Notes
+        run: >-
+          gh release create ${{ steps.tag.outputs.tag }}  --generate-notes


### PR DESCRIPTION
Add a release workflow that causes release notes to automatically get
created on tag.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
